### PR TITLE
Reconcile based on task status and support networking

### DIFF
--- a/pkg/apis/vsphereprovider/v1alpha1/vsphereproviderstatus_types.go
+++ b/pkg/apis/vsphereprovider/v1alpha1/vsphereproviderstatus_types.go
@@ -28,6 +28,12 @@ type VSphereMachineProviderStatus struct {
 	// Conditions is a set of conditions associated with the Machine to indicate
 	// errors or other status
 	// Conditions []VSphereMachineProviderCondition `json:"conditions,omitempty"`
+
+	// TaskRef is a managed object reference to a Task related to the machine.
+	// This value is set automatically at runtime and should not be set or
+	// modified by users.
+	// +optional
+	TaskRef string `json:"taskRef,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/vsphere/machine_scope.go
+++ b/pkg/controller/vsphere/machine_scope.go
@@ -79,9 +79,14 @@ func newMachineScope(params machineScopeParams) (*machineScope, error) {
 // Patch patches the machine spec and machine status after reconciling.
 func (s *machineScope) PatchMachine() error {
 	klog.V(3).Infof("%v: patching", s.machine.GetName())
-	// TODO: copy s.providerStatus in to machine.status
 	// TODO: patch machine
 
+	providerStatus, err := apivshpere.RawExtensionFromProviderStatus(s.providerStatus)
+	if err != nil {
+		return machineapierros.InvalidMachineConfiguration("failed to get machine provider status: %v", err.Error())
+	}
+
+	s.machine.Status.ProviderStatus = providerStatus
 	if err := s.client.Status().Patch(context.Background(), s.machine, s.machineToBePatched); err != nil {
 		klog.Errorf("Failed to update machine %q: %v", s.machine.GetName(), err)
 		return err

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -3,14 +3,18 @@ package vsphere
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	machinev1 "github.com/openshift/machine-api-operator/pkg/apis/machine/v1beta1"
 	vsphereapi "github.com/openshift/machine-api-operator/pkg/apis/vsphereprovider/v1alpha1"
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/property"
+	"github.com/vmware/govmomi/vim25"
 	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/klog"
 )
 
@@ -18,6 +22,7 @@ const (
 	minMemMB     = 2048
 	minCPU       = 2
 	diskMoveType = string(types.VirtualMachineRelocateDiskMoveOptionsMoveAllDiskBackingsAndConsolidate)
+	ethCardType  = "vmxnet3"
 )
 
 // Reconciler runs the logic to reconciles a machine resource towards its desired state
@@ -132,11 +137,35 @@ func (r *Reconciler) reconcileMachineWithCloudState(vm *virtualMachine) error {
 	klog.V(3).Infof("%v: reconciling machine with cloud state", r.machine.GetName())
 	// TODO: reconcile providerID
 	// TODO: reconcile task
+	klog.V(3).Infof("%v: reconciling network", r.machine.GetName())
 	return r.reconcileNetwork(vm)
 }
 
 func (r *Reconciler) reconcileNetwork(vm *virtualMachine) error {
-	// TODO: implement
+	currentNetworkStatusList, err := vm.getNetworkStatusList(r.session.Client.Client)
+	if err != nil {
+		return fmt.Errorf("error getting network status: %v", err)
+	}
+
+	//If the VM is powered on then issue requeues until all of the VM's
+	//networks have IP addresses.
+	expectNetworkLen, currentNetworkLen := len(r.providerSpec.Network.Devices), len(currentNetworkStatusList)
+	if expectNetworkLen != currentNetworkLen {
+		return errors.Errorf("invalid network count: expected=%d current=%d", expectNetworkLen, currentNetworkLen)
+	}
+
+	var ipAddrs []corev1.NodeAddress
+	for _, netStatus := range currentNetworkStatusList {
+		for _, ip := range netStatus.IPAddrs {
+			ipAddrs = append(ipAddrs, corev1.NodeAddress{
+				Type:    corev1.NodeInternalIP,
+				Address: ip,
+			})
+		}
+	}
+
+	klog.V(3).Infof("%v: reconciling network: IP addresses: %v", r.machine.GetName(), ipAddrs)
+	r.machine.Status.Addresses = ipAddrs
 	return nil
 }
 
@@ -227,6 +256,20 @@ func clone(s *machineScope) error {
 		memMiB = minMemMB
 	}
 
+	devices, err := vmTemplate.Device(s.Context)
+	if err != nil {
+		return fmt.Errorf("error getting devices %v", err)
+	}
+
+	klog.V(3).Infof("Getting network devices")
+	networkDevices, err := getNetworkDevices(s, devices)
+	if err != nil {
+		return fmt.Errorf("error getting network specs: %v", err)
+	}
+
+	var deviceSpecs []types.BaseVirtualDeviceConfigSpec
+	deviceSpecs = append(deviceSpecs, networkDevices...)
+
 	spec := types.VirtualMachineCloneSpec{
 		Config: &types.VirtualMachineConfigSpec{
 			Annotation: s.machine.GetName(),
@@ -237,8 +280,8 @@ func clone(s *machineScope) error {
 			Flags:        newVMFlagInfo(),
 			// TODO: set userData
 			//ExtraConfig:       extraConfig,
-			// TODO: set devices
-			//DeviceChange:      deviceSpecs,
+			// TODO: set disk devices
+			DeviceChange:      deviceSpecs,
 			NumCPUs:           numCPUs,
 			NumCoresPerSocket: numCoresPerSocket,
 			MemoryMB:          memMiB,
@@ -264,6 +307,57 @@ func clone(s *machineScope) error {
 	s.providerStatus.TaskRef = task.Reference().Value
 	klog.V(3).Infof("%v: running task: %+v", s.machine.GetName(), s.providerStatus.TaskRef)
 	return nil
+}
+
+func getNetworkDevices(s *machineScope, devices object.VirtualDeviceList) ([]types.BaseVirtualDeviceConfigSpec, error) {
+	var networkDevices []types.BaseVirtualDeviceConfigSpec
+	// Remove any existing NICs
+	for _, dev := range devices.SelectByType((*types.VirtualEthernetCard)(nil)) {
+		networkDevices = append(networkDevices, &types.VirtualDeviceConfigSpec{
+			Device:    dev,
+			Operation: types.VirtualDeviceConfigSpecOperationRemove,
+		})
+	}
+
+	// Add new NICs based on the machine config.
+	key := int32(-100)
+	for i := range s.providerSpec.Network.Devices {
+		netSpec := &s.providerSpec.Network.Devices[i]
+		klog.V(3).Infof("Adding device: %v", netSpec.NetworkName)
+
+		ref, err := s.GetSession().Finder.Network(s.Context, netSpec.NetworkName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to find network %q", netSpec.NetworkName)
+		}
+
+		backing, err := ref.EthernetCardBackingInfo(s.Context)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to create new ethernet card backing info for network %q", netSpec.NetworkName)
+		}
+
+		dev, err := object.EthernetCardTypes().CreateEthernetCard(ethCardType, backing)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to create new ethernet card %q for network %q", ethCardType, netSpec.NetworkName)
+		}
+
+		// Get the actual NIC object. This is safe to assert without a check
+		// because "object.EthernetCardTypes().CreateEthernetCard" returns a
+		// "types.BaseVirtualEthernetCard" as a "types.BaseVirtualDevice".
+		nic := dev.(types.BaseVirtualEthernetCard).GetVirtualEthernetCard()
+		// Assign a temporary device key to ensure that a unique one will be
+		// generated when the device is created.
+		nic.Key = key
+
+		networkDevices = append(networkDevices, &types.VirtualDeviceConfigSpec{
+			Device:    dev,
+			Operation: types.VirtualDeviceConfigSpecOperationAdd,
+		})
+		klog.V(3).Infof("Adding device: eth card type: %v, network spec: %+v, device info: %+v",
+			ethCardType, netSpec, dev.GetVirtualDevice().Backing)
+		key--
+	}
+
+	return networkDevices, nil
 }
 
 func newVMFlagInfo() *types.VirtualMachineFlagInfo {
@@ -360,4 +454,62 @@ func (vm *virtualMachine) getPowerState() (types.VirtualMachinePowerState, error
 	default:
 		return "", errors.Errorf("unexpected power state %q for vm %v", powerState, vm)
 	}
+}
+
+type NetworkStatus struct {
+	// Connected is a flag that indicates whether this network is currently
+	// connected to the VM.
+	Connected bool
+
+	// IPAddrs is one or more IP addresses reported by vm-tools.
+	IPAddrs []string
+
+	// MACAddr is the MAC address of the network device.
+	MACAddr string
+
+	// NetworkName is the name of the network.
+	NetworkName string
+}
+
+func (vm *virtualMachine) getNetworkStatusList(client *vim25.Client) ([]NetworkStatus, error) {
+	var obj mo.VirtualMachine
+	var pc = property.DefaultCollector(client)
+	var props = []string{
+		"config.hardware.device",
+		"guest.net",
+	}
+
+	if err := pc.RetrieveOne(vm.Context, vm.Ref, props, &obj); err != nil {
+		return nil, errors.Wrapf(err, "unable to fetch props %v for vm %v", props, vm.Ref)
+	}
+	klog.V(3).Infof("Getting network status: object reference: %v", obj.Reference().Value)
+	if obj.Config == nil {
+		return nil, errors.New("config.hardware.device is nil")
+	}
+
+	var networkStatusList []NetworkStatus
+	for _, device := range obj.Config.Hardware.Device {
+		if dev, ok := device.(types.BaseVirtualEthernetCard); ok {
+			nic := dev.GetVirtualEthernetCard()
+			klog.V(3).Infof("Getting network status: device: %v, macAddress: %v", nic.DeviceInfo.GetDescription().Summary, nic.MacAddress)
+			netStatus := NetworkStatus{
+				MACAddr: nic.MacAddress,
+			}
+			if obj.Guest != nil {
+				klog.V(3).Infof("Getting network status: getting guest info")
+				for _, i := range obj.Guest.Net {
+					klog.V(3).Infof("Getting network status: getting guest info: network: %+v", i)
+					if strings.EqualFold(nic.MacAddress, i.MacAddress) {
+						//TODO: sanitizeIPAddrs
+						netStatus.IPAddrs = i.IpAddress
+						netStatus.NetworkName = i.Network
+						netStatus.Connected = i.Connected
+					}
+				}
+			}
+			networkStatusList = append(networkStatusList, netStatus)
+		}
+	}
+
+	return networkStatusList, nil
 }

--- a/pkg/controller/vsphere/reconciler.go
+++ b/pkg/controller/vsphere/reconciler.go
@@ -9,6 +9,7 @@ import (
 	machinecontroller "github.com/openshift/machine-api-operator/pkg/controller/machine"
 	"github.com/pkg/errors"
 	"github.com/vmware/govmomi/object"
+	"github.com/vmware/govmomi/vim25/mo"
 	"github.com/vmware/govmomi/vim25/types"
 	"k8s.io/klog"
 )
@@ -36,8 +37,20 @@ func (r *Reconciler) create() error {
 		return fmt.Errorf("%v: failed validating machine provider spec: %v", r.machine.GetName(), err)
 	}
 
-	_, err := findVM(r.machineScope)
+	moTask, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)
 	if err != nil {
+		if !isRetrieveMONotFound(r.providerStatus.TaskRef, err) {
+			return err
+		}
+	}
+	if taskIsFinished, err := taskIsFinished(moTask); err != nil || !taskIsFinished {
+		if !taskIsFinished {
+			return fmt.Errorf("task %v has not finished", moTask.Reference().Value)
+		}
+		return err
+	}
+
+	if _, err := findVM(r.machineScope); err != nil {
 		if !IsNotFound(err) {
 			return err
 		}
@@ -55,6 +68,19 @@ func (r *Reconciler) create() error {
 func (r *Reconciler) update() error {
 	if err := validateMachine(*r.machine, *r.providerSpec); err != nil {
 		return fmt.Errorf("%v: failed validating machine provider spec: %v", r.machine.GetName(), err)
+	}
+
+	taskRef, err := r.session.GetTask(r.Context, r.providerStatus.TaskRef)
+	if err != nil {
+		if !isRetrieveMONotFound(r.providerStatus.TaskRef, err) {
+			return err
+		}
+	}
+	if taskIsFinished, err := taskIsFinished(taskRef); err != nil || !taskIsFinished {
+		if !taskIsFinished {
+			return fmt.Errorf("task %v has not finished", taskRef.Value)
+		}
+		return err
 	}
 
 	vmRef, err := findVM(r.machineScope)
@@ -156,6 +182,10 @@ func IsNotFound(err error) bool {
 	}
 }
 
+func isRetrieveMONotFound(taskRef string, err error) bool {
+	return err.Error() == fmt.Sprintf("ServerFaultCode: The object 'vim.Task:%v' has already been deleted or has not been completely created", taskRef)
+}
+
 func clone(s *machineScope) error {
 	vmTemplate, err := s.GetSession().FindVM(*s, s.providerSpec.Template)
 	if err != nil {
@@ -231,8 +261,8 @@ func clone(s *machineScope) error {
 		return errors.Wrapf(err, "error triggering clone op for machine %v", s)
 	}
 
-	// TODO: store task in providerStatus/conditions?
-	klog.V(3).Infof("%v: running task: %v", s.machine.GetName(), task.Name())
+	s.providerStatus.TaskRef = task.Reference().Value
+	klog.V(3).Infof("%v: running task: %+v", s.machine.GetName(), s.providerStatus.TaskRef)
 	return nil
 }
 
@@ -240,6 +270,31 @@ func newVMFlagInfo() *types.VirtualMachineFlagInfo {
 	diskUUIDEnabled := true
 	return &types.VirtualMachineFlagInfo{
 		DiskUuidEnabled: &diskUUIDEnabled,
+	}
+}
+
+func taskIsFinished(task *mo.Task) (bool, error) {
+	if task == nil {
+		return true, nil
+	}
+
+	// Otherwise the course of action is determined by the state of the task.
+	klog.V(3).Infof("task: %v, state: %v, description-id: %v", task.Reference().Value, task.Info.State, task.Info.DescriptionId)
+	switch task.Info.State {
+	case types.TaskInfoStateQueued:
+		klog.V(3).Info("task is still pending")
+		return false, nil
+	case types.TaskInfoStateRunning:
+		klog.V(3).Info("task is still running")
+		return false, nil
+	case types.TaskInfoStateSuccess:
+		klog.V(3).Info("task has succeeded")
+		return true, nil
+	case types.TaskInfoStateError:
+		klog.V(3).Info("task has failed")
+		return true, nil
+	default:
+		return false, errors.Errorf("task: %v, unknown state %v", task.Reference().Value, task.Info.State)
 	}
 }
 
@@ -256,16 +311,16 @@ func (vm *virtualMachine) reconcilePowerState() (bool, error) {
 	}
 	switch powerState {
 	case types.VirtualMachinePowerStatePoweredOff:
-		klog.Infof("powering on")
+		klog.Infof("%v: powering on", vm.Obj.Reference().Value)
 		_, err := vm.powerOnVM()
 		if err != nil {
 			return false, errors.Wrapf(err, "failed to trigger power on op for vm %q", vm)
 		}
 		// TODO: store task in providerStatus/conditions?
-		klog.Infof("requeue to wait for power on state")
+		klog.Infof("%v: requeue to wait for power on state", vm.Obj.Reference().Value)
 		return false, nil
 	case types.VirtualMachinePowerStatePoweredOn:
-		klog.Infof("powered on")
+		klog.Infof("%v: powered on", vm.Obj.Reference().Value)
 	default:
 		return false, errors.Errorf("unexpected power state %q for vm %q", powerState, vm)
 	}

--- a/pkg/controller/vsphere/reconciler_test.go
+++ b/pkg/controller/vsphere/reconciler_test.go
@@ -1,12 +1,9 @@
 /*
 Copyright 2018 The Kubernetes Authors.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,6 +16,8 @@ package vsphere
 import (
 	"context"
 	"crypto/tls"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/vmware/govmomi/vim25/mo"
@@ -371,10 +370,189 @@ func TestTaskIsFinished(t *testing.T) {
 	}
 }
 
+func TestGetNetworkDevices(t *testing.T) {
+	model, session, server := initSimulator(t)
+	defer model.Remove()
+	defer server.Close()
+
+	managedObj := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	objVM := object.NewVirtualMachine(session.Client.Client, managedObj.Reference())
+
+	devices, err := objVM.Device(context.TODO())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// checking network has been created by default
+	_, err = session.Finder.Network(context.TODO(), "VM Network")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	testCases := []struct {
+		testCase     string
+		providerSpec *vsphereapi.VSphereMachineProviderSpec
+		expected     func(gotDevices []types.BaseVirtualDeviceConfigSpec) bool
+	}{
+		{
+			testCase:     "no Network",
+			providerSpec: &vsphereapi.VSphereMachineProviderSpec{},
+			expected: func(gotDevices []types.BaseVirtualDeviceConfigSpec) bool {
+				if len(gotDevices) != 1 {
+					return false
+				}
+				if gotDevices[0].GetVirtualDeviceConfigSpec().Operation != types.VirtualDeviceConfigSpecOperationRemove {
+					return false
+				}
+				return true
+			},
+		},
+		{
+			testCase: "one Network",
+			providerSpec: &vsphereapi.VSphereMachineProviderSpec{
+				Network: vsphereapi.NetworkSpec{
+					Devices: []vsphereapi.NetworkDeviceSpec{
+						{
+							NetworkName: "VM Network",
+						},
+					},
+				},
+			},
+			expected: func(gotDevices []types.BaseVirtualDeviceConfigSpec) bool {
+				if len(gotDevices) != 2 {
+					return false
+				}
+				if gotDevices[0].GetVirtualDeviceConfigSpec().Operation != types.VirtualDeviceConfigSpecOperationRemove {
+					return false
+				}
+				if gotDevices[1].GetVirtualDeviceConfigSpec().Operation != types.VirtualDeviceConfigSpecOperationAdd {
+					return false
+				}
+				return true
+			},
+		},
+	}
+	// TODO: verify GetVirtualDeviceConfigSpec().Device values
+
+	for _, tc := range testCases {
+		t.Run(tc.testCase, func(t *testing.T) {
+			machineScope := &machineScope{
+				Context:      context.TODO(),
+				providerSpec: tc.providerSpec,
+				session:      session,
+			}
+			networkDevices, err := getNetworkDevices(machineScope, devices)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !tc.expected(networkDevices) {
+				t.Errorf("Got unexpected networkDevices len (%v) or operations (%v)",
+					len(networkDevices),
+					printOperations(networkDevices))
+			}
+		})
+	}
+}
+
+func printOperations(networkDevices []types.BaseVirtualDeviceConfigSpec) string {
+	var output string
+	for i := range networkDevices {
+		output += fmt.Sprintf("device: %v has operation: %v, ", i, string(networkDevices[i].GetVirtualDeviceConfigSpec().Operation))
+	}
+	return output
+}
+
+func TestGetNetworkStatusList(t *testing.T) {
+	model, session, server := initSimulator(t)
+	defer model.Remove()
+	defer server.Close()
+
+	managedObj := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	defaultFakeIPs := []string{"127.0.0.1"}
+	managedObj.Guest.Net[0].IpAddress = defaultFakeIPs
+	managedObjRef := object.NewVirtualMachine(session.Client.Client, managedObj.Reference()).Reference()
+
+	vm := &virtualMachine{
+		Context: context.TODO(),
+		Obj:     object.NewVirtualMachine(session.Client.Client, managedObjRef),
+		Ref:     managedObjRef,
+	}
+
+	defaultFakeMAC := "00:0c:29:33:34:38"
+	expectedNetworkStatusList := []NetworkStatus{
+		{
+			IPAddrs:   defaultFakeIPs,
+			Connected: true,
+			MACAddr:   defaultFakeMAC,
+		},
+	}
+
+	// validations
+	networkStatusList, err := vm.getNetworkStatusList(session.Client.Client)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(networkStatusList) != 1 {
+		t.Errorf("Expected networkStatusList len to be 1, got %v", len(networkStatusList))
+	}
+	if !reflect.DeepEqual(networkStatusList, expectedNetworkStatusList) {
+		t.Errorf("Expected: %v, got: %v", networkStatusList, expectedNetworkStatusList)
+	}
+	// TODO: add more cases by adding network devices to the NewVirtualMachine() object
+}
+
+func TestReconcileNetwork(t *testing.T) {
+	model, session, server := initSimulator(t)
+	defer model.Remove()
+	defer server.Close()
+
+	managedObj := simulator.Map.Any("VirtualMachine").(*simulator.VirtualMachine)
+	managedObj.Guest.Net[0].IpAddress = []string{"127.0.0.1"}
+	managedObjRef := object.NewVirtualMachine(session.Client.Client, managedObj.Reference()).Reference()
+
+	vm := &virtualMachine{
+		Context: context.TODO(),
+		Obj:     object.NewVirtualMachine(session.Client.Client, managedObjRef),
+		Ref:     managedObjRef,
+	}
+
+	expectedAddresses := []corev1.NodeAddress{
+		{
+			Type:    corev1.NodeInternalIP,
+			Address: "127.0.0.1",
+		},
+	}
+	r := &Reconciler{
+		machineScope: &machineScope{
+			Context: context.TODO(),
+			session: session,
+			machine: &machinev1.Machine{
+				Status: machinev1.MachineStatus{},
+			},
+			providerSpec: &vsphereapi.VSphereMachineProviderSpec{
+				Network: vsphereapi.NetworkSpec{
+					Devices: []vsphereapi.NetworkDeviceSpec{
+						{
+							NetworkName: "dummy",
+						},
+					},
+				},
+			},
+		},
+	}
+	if err := r.reconcileNetwork(vm); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(expectedAddresses, r.machineScope.machine.Status.Addresses) {
+		t.Errorf("Expected: %v, got: %v", expectedAddresses, r.machineScope.machine.Status.Addresses)
+	}
+	// TODO: add more cases by adding network devices to the NewVirtualMachine() object
+}
+
 // TODO TestCreate()
 // TODO TestUpdate()
 // TODO TestExist()
-// TODO TestReconcileNetwork()
 // TODO TestReconcileMachineWithCloudState()
-// TODO TestGetNetworkStatus()
 // See https://github.com/vmware/govmomi/blob/master/simulator/example_extend_test.go#L33:6 for extending behaviour example


### PR DESCRIPTION
Reconcile based on task status.
Support networking devices and set IPs on status.

```
I1220 10:35:09.907747   27157 reconciler.go:123] test: does not exist
I1220 10:35:09.907828   27157 controller.go:386] test: going into phase "Provisioning"
I1220 10:35:10.067193   27157 controller.go:295] test: reconciling machine triggers idempotent create
I1220 10:35:10.067239   27157 actuator.go:56] test: actuator creating machine
I1220 10:35:11.229458   27157 reconciler.go:63] test: cloning
I1220 10:35:11.229524   27157 session.go:101] Find template by instance uuid Workloads/Cuppett Fedora
I1220 10:35:11.533673   27157 session.go:111] Find template by name Workloads/Cuppett Fedora
I1220 10:35:22.403051   27157 reconciler.go:264] Getting network devices
I1220 10:35:22.403191   27157 reconciler.go:326] Adding device: Workload Network
I1220 10:35:23.227008   27157 reconciler.go:355] Adding device: eth card type: vmxnet3, network spec: &{NetworkName:Workload Network}, device info: &{VirtualDeviceBackingInfo:{DynamicData:{}} OpaqueNetworkId:03291084-6e41-4641-926d-8360a8860605 OpaqueNetworkType:nsx.LogicalSwitch}
I1220 10:35:23.581553   27157 reconciler.go:308] test: running task: task-9959
I1220 10:35:23.581635   27157 machine_scope.go:81] test: patching
I1220 10:35:23.891511   27157 controller.go:307] test: created instance, requeuing
I1220 10:35:23.891604   27157 controller.go:162] test: reconciling Machine
I1220 10:35:23.891623   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:35:24.450728   27157 reconciler.go:123] test: does not exist
I1220 10:35:24.450768   27157 controller.go:295] test: reconciling machine triggers idempotent create
I1220 10:35:24.450781   27157 actuator.go:56] test: actuator creating machine
I1220 10:35:25.019912   27157 reconciler.go:376] task: task-9959, state: running, description-id: VirtualMachine.clone
I1220 10:35:25.020002   27157 reconciler.go:382] task is still running
I1220 10:35:25.020026   27157 machine_scope.go:81] test: patching
E1220 10:35:25.330055   27157 actuator.go:47] test error: task task-9959 has not finished
W1220 10:35:25.330242   27157 controller.go:297] test: failed to create machine: task task-9959 has not finished
I1220 10:35:26.333707   27157 controller.go:162] test: reconciling Machine
I1220 10:35:26.333801   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:35:27.006557   27157 reconciler.go:123] test: does not exist
I1220 10:35:27.006587   27157 controller.go:295] test: reconciling machine triggers idempotent create
I1220 10:35:27.006597   27157 actuator.go:56] test: actuator creating machine
I1220 10:35:27.579505   27157 reconciler.go:376] task: task-9959, state: running, description-id: VirtualMachine.clone
I1220 10:35:27.579576   27157 reconciler.go:382] task is still running
I1220 10:35:27.579593   27157 machine_scope.go:81] test: patching
E1220 10:35:27.733998   27157 actuator.go:47] test error: task task-9959 has not finished
W1220 10:35:27.734039   27157 controller.go:297] test: failed to create machine: task task-9959 has not finished
I1220 10:35:28.736921   27157 controller.go:162] test: reconciling Machine
I1220 10:35:28.736969   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:35:29.350993   27157 reconciler.go:123] test: does not exist
I1220 10:35:29.351030   27157 controller.go:295] test: reconciling machine triggers idempotent create
I1220 10:35:29.351049   27157 actuator.go:56] test: actuator creating machine
I1220 10:35:30.080727   27157 reconciler.go:376] task: task-9959, state: running, description-id: VirtualMachine.clone
I1220 10:35:30.080837   27157 reconciler.go:382] task is still running
I1220 10:35:30.080858   27157 machine_scope.go:81] test: patching
E1220 10:35:30.235488   27157 actuator.go:47] test error: task task-9959 has not finished
W1220 10:35:30.235552   27157 controller.go:297] test: failed to create machine: task task-9959 has not finished
I1220 10:35:31.240436   27157 controller.go:162] test: reconciling Machine
I1220 10:35:31.240580   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:35:31.821347   27157 reconciler.go:123] test: does not exist
I1220 10:35:31.821386   27157 controller.go:295] test: reconciling machine triggers idempotent create
I1220 10:35:31.821401   27157 actuator.go:56] test: actuator creating machine
I1220 10:35:32.640679   27157 reconciler.go:376] task: task-9959, state: running, description-id: VirtualMachine.clone
I1220 10:35:32.640744   27157 reconciler.go:382] task is still running
I1220 10:35:32.640758   27157 machine_scope.go:81] test: patching
E1220 10:35:32.793749   27157 actuator.go:47] test error: task task-9959 has not finished
W1220 10:35:32.793865   27157 controller.go:297] test: failed to create machine: task task-9959 has not finished
I1220 10:35:33.797941   27157 controller.go:162] test: reconciling Machine
I1220 10:35:33.798006   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:35:34.590401   27157 reconciler.go:123] test: does not exist
I1220 10:35:34.590438   27157 controller.go:295] test: reconciling machine triggers idempotent create
I1220 10:35:34.590448   27157 actuator.go:56] test: actuator creating machine
I1220 10:35:35.200738   27157 reconciler.go:376] task: task-9959, state: running, description-id: VirtualMachine.clone
I1220 10:35:35.200786   27157 reconciler.go:382] task is still running
I1220 10:35:35.200818   27157 machine_scope.go:81] test: patching
E1220 10:35:35.359164   27157 actuator.go:47] test error: task task-9959 has not finished
W1220 10:35:35.359241   27157 controller.go:297] test: failed to create machine: task task-9959 has not finished
I1220 10:35:36.364256   27157 controller.go:162] test: reconciling Machine
I1220 10:35:36.364304   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:35:36.960535   27157 reconciler.go:126] test: already exists
I1220 10:35:36.960588   27157 controller.go:259] test: reconciling machine triggers idempotent update
I1220 10:35:36.960607   27157 actuator.go:89] test: actuator updating machine
I1220 10:35:37.565619   27157 reconciler.go:376] task: task-9959, state: success, description-id: VirtualMachine.clone
I1220 10:35:37.565673   27157 reconciler.go:385] task has succeeded
I1220 10:35:38.126731   27157 reconciler.go:408] vm-2107: powering on
I1220 10:35:38.477482   27157 reconciler.go:414] vm-2107: requeue to wait for power on state
I1220 10:35:38.477588   27157 machine_scope.go:81] test: patching
E1220 10:35:38.982144   27157 controller.go:266] test: instance exists but providerID or addresses has not been given to the machine yet, requeuing
I1220 10:36:08.986859   27157 controller.go:162] test: reconciling Machine
I1220 10:36:08.986909   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:36:09.516403   27157 reconciler.go:126] test: already exists
I1220 10:36:09.516470   27157 controller.go:259] test: reconciling machine triggers idempotent update
I1220 10:36:09.516491   27157 actuator.go:89] test: actuator updating machine
I1220 10:36:10.042636   27157 reconciler.go:376] task: task-9959, state: success, description-id: VirtualMachine.clone
I1220 10:36:10.042672   27157 reconciler.go:385] task has succeeded
I1220 10:36:10.895016   27157 reconciler.go:417] vm-2107: powered on
I1220 10:36:10.895068   27157 reconciler.go:137] test: reconciling machine with cloud state
I1220 10:36:10.895092   27157 reconciler.go:140] test: reconciling network
I1220 10:36:11.858694   27157 reconciler.go:485] Getting network status: object reference: vm-2107
I1220 10:36:11.858735   27157 reconciler.go:494] Getting network status: device: nsx.LogicalSwitch: 03291084-6e41-4641-926d-8360a8860605, macAddress: 00:50:56:98:92:69
I1220 10:36:11.858751   27157 reconciler.go:499] Getting network status: getting guest info
I1220 10:36:11.858760   27157 reconciler.go:167] test: reconciling network: IP addresses: []
I1220 10:36:11.858791   27157 machine_scope.go:81] test: patching
E1220 10:36:12.046366   27157 controller.go:266] test: instance exists but providerID or addresses has not been given to the machine yet, requeuing
I1220 10:36:42.052039   27157 controller.go:162] test: reconciling Machine
I1220 10:36:42.052094   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:36:42.606070   27157 reconciler.go:126] test: already exists
I1220 10:36:42.606106   27157 controller.go:259] test: reconciling machine triggers idempotent update
I1220 10:36:42.606116   27157 actuator.go:89] test: actuator updating machine
I1220 10:36:43.398388   27157 reconciler.go:376] task: task-9959, state: success, description-id: VirtualMachine.clone
I1220 10:36:43.398423   27157 reconciler.go:385] task has succeeded
I1220 10:36:44.012416   27157 reconciler.go:417] vm-2107: powered on
I1220 10:36:44.012441   27157 reconciler.go:137] test: reconciling machine with cloud state
I1220 10:36:44.012450   27157 reconciler.go:140] test: reconciling network
I1220 10:36:44.585711   27157 reconciler.go:485] Getting network status: object reference: vm-2107
I1220 10:36:44.585737   27157 reconciler.go:494] Getting network status: device: nsx.LogicalSwitch: 03291084-6e41-4641-926d-8360a8860605, macAddress: 00:50:56:98:92:69
I1220 10:36:44.585745   27157 reconciler.go:499] Getting network status: getting guest info
I1220 10:36:44.585751   27157 reconciler.go:501] Getting network status: getting guest info: network: {DynamicData:{} Network: IpAddress:[192.168.1.184 fe80::b923:968:9f78:8280 fe80::f177:e792:fc66:3191] MacAddress:00:50:56:98:92:69 Connected:true DeviceConfigId:4000 DnsConfig:<nil> IpConfig:0xc0004f9b90 NetBIOSConfig:<nil>}
I1220 10:36:44.585782   27157 reconciler.go:167] test: reconciling network: IP addresses: [{InternalIP 192.168.1.184} {InternalIP fe80::b923:968:9f78:8280} {InternalIP fe80::f177:e792:fc66:3191}]
I1220 10:36:44.585810   27157 machine_scope.go:81] test: patching
I1220 10:36:44.757354   27157 controller.go:386] test: going into phase "Provisioned"
I1220 10:36:44.917738   27157 controller.go:275] test: has no node yet, requeuing
I1220 10:36:44.917815   27157 controller.go:162] test: reconciling Machine
I1220 10:36:44.917837   27157 actuator.go:76] test: actuator checking if machine exists
I1220 10:36:45.663232   27157 reconciler.go:126] test: already exists
I1220 10:36:45.663264   27157 controller.go:259] test: reconciling machine triggers idempotent update
I1220 10:36:45.663277   27157 actuator.go:89] test: actuator updating machine
I1220 10:36:46.367779   27157 reconciler.go:376] task: task-9959, state: success, description-id: VirtualMachine.clone
I1220 10:36:46.367824   27157 reconciler.go:385] task has succeeded
I1220 10:36:46.940618   27157 reconciler.go:417] vm-2107: powered on
I1220 10:36:46.940706   27157 reconciler.go:137] test: reconciling machine with cloud state
I1220 10:36:46.940721   27157 reconciler.go:140] test: reconciling network
I1220 10:36:47.538220   27157 reconciler.go:485] Getting network status: object reference: vm-2107
I1220 10:36:47.538250   27157 reconciler.go:494] Getting network status: device: nsx.LogicalSwitch: 03291084-6e41-4641-926d-8360a8860605, macAddress: 00:50:56:98:92:69
I1220 10:36:47.538265   27157 reconciler.go:499] Getting network status: getting guest info
I1220 10:36:47.538274   27157 reconciler.go:501] Getting network status: getting guest info: network: {DynamicData:{} Network: IpAddress:[192.168.1.184 fe80::b923:968:9f78:8280 fe80::f177:e792:fc66:3191] MacAddress:00:50:56:98:92:69 Connected:true DeviceConfigId:4000 DnsConfig:<nil> IpConfig:0xc00042af00 NetBIOSConfig:<nil>}
I1220 10:36:47.538303   27157 reconciler.go:167] test: reconciling network: IP addresses: [{InternalIP 192.168.1.184} {InternalIP fe80::b923:968:9f78:8280} {InternalIP fe80::f177:e792:fc66:3191}]
I1220 10:36:47.538391   27157 machine_scope.go:81] test: patching
I1220 10:36:47.702321   27157 controller.go:275] test: has no node yet, requeuing
```

```
status:
  addresses:
  - address: 192.168.1.184
    type: InternalIP
  - address: fe80::b923:968:9f78:8280
    type: InternalIP
  - address: fe80::f177:e792:fc66:3191
    type: InternalIP
  lastUpdated: "2019-12-20T09:36:44Z"
  phase: Provisioned
  providerStatus:
    metadata: {}
    taskRef: task-9959
```